### PR TITLE
#74: Use tox for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 **/__pycache__/
 **/*.py[co]
 artifacts/
+.tox/
 
 collected-static/
 django

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ cache: pip
 
 python:
   - '3.6'
+  - '3.7-dev'
+
+matrix:
+  allow_failures:
+    - python: 3.7-dev
 
 services:
   - postgresql
@@ -11,12 +16,12 @@ services:
   - docker
 
 install:
+  - pip install tox-travis
   - pip install -r requirements.txt
 
 script:
-  - flake8
+  - tox
   - ./manage.py migrate
-  - pytest
   - docker build -t pyslackers/website:latest -t pyslackers/website:$TRAVIS_BUILD_NUMBER .
 
 deploy:
@@ -24,3 +29,6 @@ deploy:
   script: scripts/deploy.sh
   on:
     branch: master
+    tags: false
+    repo: pyslackers/website
+    python: "3.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ exclude = .tox,.git,*/migrations/*,node_modules
 [tool:pytest]
 DJANGO_SETTINGS_MODULE = config.settings.testing
 addopts =
-    --cov=.
+    --cov=pyslackers_website
     --cov-report=term-missing
     --cov-report html:artifacts/coverage
     --junit-xml=artifacts/test_reports.xml

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py36, py37, flake8
+skipsdist = True
+
+[travis]
+python =
+    3.6: py36
+    3.7-dev: py37
+unignore_outcomes = True
+
+[testenv:flake8]
+basepython = python
+deps = flake8
+commands = flake8 pyslackers_website
+
+[testenv]
+setenv =
+    PYTHONPATH = {toxinidir}
+deps =
+    -r{toxinidir}/requirements.txt
+commands = python -m pytest


### PR DESCRIPTION
### Relevant Issue:

Closes #74 - let's use `tox`

### Description of Changes

Uses tox in travis, also allows local `tox` usage

### Screenshots, if applicable

n/a

### Requirements

- [ ] Tests
- [ ] Documentation
- [ ] Ansible updates, if applicable (see [pyslackers/ansible](https://github.com/pyslackers/ansible))