### PR TITLE
#17 Refactor slack invite js and leaflet map

### DIFF
--- a/ansible/templates/etc/default/pyslackersweb.j2
+++ b/ansible/templates/etc/default/pyslackersweb.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 
 DATABASE_URL=postgres://{{ database.user }}:{{ database.password }}@{{ database.host | default('127.0.0.1') }}:{{ database.port | default(5432) }}/{{ database.name }}
-GUNICORN_CMD_ARGS="--bind=127.0.0.1:8000 --workers=4 --access-logfile - --log-level debug --capture-output --log-syslog"
+GUNICORN_CMD_ARGS="--bind=127.0.0.1:8000 --workers=2 --access-logfile - --log-level debug --capture-output --log-syslog"
 REDIS_URL=redis://
 SECRET_KEY={{ secret_key }}
 EMAIL_USER={{ sendgrid.username }}

--- a/pyslackers_website/slack/static/js/member_map.js
+++ b/pyslackers_website/slack/static/js/member_map.js
@@ -376,7 +376,7 @@ function buildMap(slackMemberTZCount) {
         maxZoom: 5
     });
 
-    L.tileLayer('http://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png', {
+    L.tileLayer('https://cartocdn_{s}.global.ssl.fastly.net/base-light/{z}/{x}/{y}.png', {
         attribution: 'PySlackers Member List by Time Zone | Maps by cartocdn.com',
         noWrap: true
     }).addTo(map);
@@ -397,17 +397,17 @@ function buildMap(slackMemberTZCount) {
     return map;
 }
 
-{
+function setupMembershipMap(slackMemberTimezones) {
     let map;
     $(window).on('orientationchange pageshow resize', () => {
         if (!map) {
-            map = buildMap(slack_member_tz_count); // eslint-disable-line no-undef
+            map = buildMap(slackMemberTimezones);
         }
-
-        $('#leaflet_member_map').height($('#leaflet_container').height());
-        $('#leaflet_member_map').width($('#leaflet_container').width());
+        const mapElem = $('#leaflet_member_map'),
+            mapContainer = $('#leaflet_container');
+        mapElem.height(mapContainer.height());
+        mapElem.width(mapContainer.width());
         map.invalidateSize();
         map.setView([10, 0], 0);
     }).trigger('resize');
 }
-

--- a/pyslackers_website/slack/static/js/slack_invite.js
+++ b/pyslackers_website/slack/static/js/slack_invite.js
@@ -1,5 +1,5 @@
 $(document).ready(function () {
-    $('#invite_form')
+    $('#slack_invite_form')
         .form({
             fields: {
                 email: {

--- a/pyslackers_website/slack/templates/slack/index.html
+++ b/pyslackers_website/slack/templates/slack/index.html
@@ -1,6 +1,16 @@
 {% extends 'slack/base.html' %}
 
-{% load humanize %}
+{% load humanize static %}
+
+{% block extra_script %}
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.2.0/leaflet.js"></script>
+    <script src="{% static 'js/member_map.js' %}"></script>
+    <script src="{% static 'js/slack_invite.js' %}"></script>
+{% endblock %}
+
+{% block extra_link %}
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.2.0/leaflet.css" />
+{% endblock %}
 
 {% block content %}
     <div class="ui container">
@@ -10,82 +20,9 @@
                 members.
             </span>
         </h2>
+
         {% if slack_member_tz_count %} {% include 'slack/partials/member_map.html' %} {% endif %}
 
-        <form class="ui form {% if form.errors %}error{% endif %}"
-              id="slack_invite_form" method="post">
-            {% csrf_token %}
-
-            <div class="field {% if form.email.errors %}error{% endif %}">
-                <label for="{{ form.email.name }}">Email</label>
-                <input id="{{ form.email.name }}" name="{{ form.email.name }}"
-                       placeholder="Email" type="email"
-                       value="{{ form.email.value | default_if_none:"" }}"
-                       required/>
-            </div>
-
-            {#            <div class="field {% if form.additional_channels.errors %}error{% endif %}">#}
-            {#                <label for="{{ form.additional_channels.name }}">Join some channels</label>#}
-            {#                <select class="ui fluid search dropdown" multiple="" name="{{ form.additional_channels.name  }}">#}
-            {#                    <option value="">Channels</option>#}
-            {#                    {% for channel in slack_channels %}#}
-            {#                        <option value="{{ channel.name }}" {% if channel.name in form.additional_channels.value %}selected{% endif %}>{{ channel.name }} - {{ channel.members }}</option>#}
-            {#                    {% endfor %}#}
-            {#                </select>#}
-            {#            </div>#}
-
-            <div class="field {% if form.accept_tos.errors %}error{% endif %}">
-                <div class="ui checkbox">
-                    <input id="{{ form.accept_tos.name }}" class="hidden"
-                           name="{{ form.accept_tos.name }}" type="checkbox"
-                           required
-                           {% if form.accept_tos.value %}checked{% endif %}/>
-                    <label for="{{ form.accept_tos.name }}">I agree to the <a
-                            href="{% url 'marketing:tos' %}">
-                        Terms and Code of Conduct</a></label>
-                </div>
-            </div>
-
-            <div class="ui error message">
-                <div class="header">We had some issues</div>
-                <ul class="list">
-                    {% for field in form %}
-                        {% for error in field.errors %}
-                            <li>{{ error }}</li>
-                        {% endfor %}
-                    {% endfor %}
-                </ul>
-            </div>
-
-            <button class="ui button">Submit</button>
-        </form>
-
-{#        <h2 class="ui header">#}
-{#            About Us#}
-{#        </h2>#}
-{##}
-{#        <p>#}
-{#            We are a global community of {{ slack_member_count | intcomma }}#}
-{#            Pythonistas with diverse specialties. Join us to talk about python,#}
-{#            music, devops, science,#}
-{#            <a href="https://github.com/pyslackers">community projects</a>, etc.#}
-{#        </p>#}
-{##}
-{#        <h2 class="ui header">#}
-{#            Member Statistics#}
-{#        </h2>#}
-{##}
-{#        <ul class="list">#}
-{#            <li>timezone breakdown</li>#}
-{#            <li>message stats?</li>#}
-{#        </ul>#}
-{##}
-{#        <h2 class="ui header">#}
-{#            Current Channels#}
-{#        </h2>#}
-{##}
-{#        <p>#}
-{#            TODO channel list...#}
-{#        </p>#}
+        {% include 'slack/partials/invite_form.html' %}
     </div>
 {% endblock %}

--- a/pyslackers_website/slack/templates/slack/partials/invite_form.html
+++ b/pyslackers_website/slack/templates/slack/partials/invite_form.html
@@ -1,0 +1,34 @@
+<form class="ui form {% if form.errors %}error{% endif %}" id="slack_invite_form" method="post">
+    {% csrf_token %}
+
+    <div class="field required {% if form.email.errors %}error{% endif %}">
+        <label for="{{ form.email.name }}">Email</label>
+        <input id="{{ form.email.name }}" name="{{ form.email.name }}"
+               placeholder="Email" type="email"
+               value="{{ form.email.value | default_if_none:"" }}"/>
+    </div>
+
+    <div class="field required {% if form.accept_tos.errors %}error{% endif %}">
+        <div class="ui checkbox">
+            <input id="{{ form.accept_tos.name }}" class="hidden"
+                   name="{{ form.accept_tos.name }}" type="checkbox"
+                   {% if form.accept_tos.value %}checked{% endif %}/>
+            <label for="{{ form.accept_tos.name }}">I agree to the <a
+                    href="{% url 'marketing:tos' %}">
+                Terms and Code of Conduct</a></label>
+        </div>
+    </div>
+
+    <div class="ui error message">
+        <div class="header">We had some issues</div>
+        <ul class="list">
+            {% for field in form %}
+                {% for error in field.errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            {% endfor %}
+        </ul>
+    </div>
+
+    <button class="ui button">Submit</button>
+</form>

--- a/pyslackers_website/slack/templates/slack/partials/member_map.html
+++ b/pyslackers_website/slack/templates/slack/partials/member_map.html
@@ -1,20 +1,11 @@
-{% load static %}
 {% load tojson %}
 
-<div class="ui container" >
-  <div class="ui container segment" id="leaflet_container">
-    <div id="leaflet_member_map" />
-  </div>
+<div class="ui container segment" id="leaflet_container">
+    <div id="leaflet_member_map" style="min-height: 425px;"></div>
 </div>
+
 <script type="text/javascript">
-  const slack_member_tz_count = {{ slack_member_tz_count | tojson }};
+    $(document).ready(function() {
+      setupMembershipMap({{ slack_member_tz_count | tojson }});
+    });
 </script>
-
-{% block extra_script %}
-<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.2.0/leaflet.js"></script>
-<script src="{% static 'js/member_map.js' %}"></script>
-{% endblock %}
-
-{% block extra_link %}
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.2.0/leaflet.css" />
-{% endblock %}


### PR DESCRIPTION
### Relevant Issue:

Closes #17

### Description of Changes

* Dropped gunicorn workers for memory usage, we don't have enough load to bother with 4 anyway
* Use the SSL endpoint for the leaflet map tiles to avoid insecure content loading
* Fixes slack invite form validations to use the semantic JS
* Delete out a bunch of commented out code, unused file(s)
* Instead of depending on a global variable for the membership map, this calls the function to generate it with the data.

### Screenshots, if applicable

N/A

### Requirements

- [ ] Tests
- [ ] Documentation
- [ ] Ansible updates, if applicable (see [pyslackers/ansible](https://github.com/pyslackers/ansible))