### PR TITLE
Closes #47: Adds rate limiting for the slack invite form

### DIFF
--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -1,9 +1,11 @@
 from ._base import *  # noqa
 
-CACHES['default']['OPTIONS'] = {  # noqa
-    'REDIS_CLIENT_CLASS': 'fakeredis.FakeStrictRedis',
-}
-
 CELERY_ALWAYS_EAGER = True
 
 SECRET_KEY = 'PYSLACKERS_TESTING_SECRET_KEY'
+
+############
+# RATE LIMIT
+############
+
+RATELIMIT_CACHE_PREFIX = 'rl:test:'

--- a/pyslackers_website/slack/views.py
+++ b/pyslackers_website/slack/views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.core.cache import cache
 from django.core.urlresolvers import reverse_lazy
 from django.views.generic import FormView
-
+from ratelimit.decorators import ratelimit
 
 from .forms import SlackInviteForm
 from .tasks import send_slack_invite
@@ -26,6 +26,7 @@ class SlackInvite(FormView):
         )
         return context
 
+    @ratelimit(key='ip', rate='10/h', method='POST', block=True)
     def post(self, request, *args, **kwargs):
         form = self.get_form()
         if form.is_valid():

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,8 +10,8 @@ Django==1.11.4
 django-allauth==0.32.0
 django-celery-beat==1.0.1
 django-debug-toolbar==1.8
+django-ratelimit==1.0.1
 django-redis==4.8.0
-fakeredis==0.8.2
 flake8==3.4.1
 greenlet==0.4.12
 gunicorn==19.7.1


### PR DESCRIPTION
### Relevant Issue:

Closes #47

### Description of Changes

Rate limiting added for slack invite form, 10/hr for all IPs

### Screenshots, if applicable

N/A

### Requirements

- [x] Tests
- [ ] Documentation
- [ ] Ansible updates, if applicable (see [pyslackers/ansible](https://github.com/pyslackers/ansible))