### PR TITLE
Make tz count async

### DIFF
--- a/client/slack/member_map.js
+++ b/client/slack/member_map.js
@@ -360,22 +360,20 @@ const timezoneMapping = {
 };
 
 function buildMap(slackMemberTZCount) {
-    const features = Object.entries(slackMemberTZCount)
-        .map(([timezone, memberCount]) => ({
-            geometry: {
-                type: 'Point',
-                coordinates: [
-                    timezoneMapping[timezone][1],
-                    timezoneMapping[timezone][0]
-                ]
-            },
-            type: 'Feature',
-            properties: {
-                popupContent: `<h3>${timezone}: ${memberCount} members</h3>`,
-                member_count: memberCount
-            },
-            })
-        );
+    const features = Object.entries(slackMemberTZCount).map(([timezone, memberCount]) => ({
+        geometry: {
+            type: 'Point',
+            coordinates: [
+                timezoneMapping[timezone][1],
+                timezoneMapping[timezone][0]
+            ]
+        },
+        type: 'Feature',
+        properties: {
+            popupContent: `<h3>${timezone}: ${memberCount} members</h3>`,
+            member_count: memberCount
+        },
+    }));
 
     const map = L.map('leaflet_member_map', {
         minZoom: 1.5,

--- a/client/slack/member_map.js
+++ b/client/slack/member_map.js
@@ -360,20 +360,22 @@ const timezoneMapping = {
 };
 
 function buildMap(slackMemberTZCount) {
-    const features = slackMemberTZCount.map(([timezone, memberCount]) => ({
-        geometry: {
-            type: 'Point',
-            coordinates: [
-                timezoneMapping[timezone][1],
-                timezoneMapping[timezone][0]
-            ]
-        },
-        type: 'Feature',
-        properties: {
-            popupContent: `<h3>${timezone}: ${memberCount} members</h3>`,
-            member_count: memberCount
-        },
-    }));
+    const features = Object.entries(slackMemberTZCount)
+        .map(([timezone, memberCount]) => ({
+            geometry: {
+                type: 'Point',
+                coordinates: [
+                    timezoneMapping[timezone][1],
+                    timezoneMapping[timezone][0]
+                ]
+            },
+            type: 'Feature',
+            properties: {
+                popupContent: `<h3>${timezone}: ${memberCount} members</h3>`,
+                member_count: memberCount
+            },
+            })
+        );
 
     const map = L.map('leaflet_member_map', {
         minZoom: 1.5,

--- a/client/slack/slack.js
+++ b/client/slack/slack.js
@@ -8,6 +8,9 @@ import setupMemberMap from './member_map';
 
 
 $(() => {
-    let data = JSON.parse($('#slack_member_tz_count').html());
-    setupMemberMap(data);
+    const mapContainer = $('#leaflet_container');
+    $.get('/slack/api/timezones')
+        .done(body => setupMemberMap(body))
+        .fail(() => setupMemberMap({}))
+        .always(() => mapContainer.removeClass('loading'));
 });

--- a/client/slack/slack.js
+++ b/client/slack/slack.js
@@ -8,13 +8,6 @@ import setupMemberMap from './member_map';
 
 
 $(() => {
-    let data = $('#slack_member_tz_count').data('timezones');
-    if (data !== undefined) {
-        // convert python list of tuples
-        data = data
-            .replace(/\(/g, '[')
-            .replace(/\)/g, ']')
-            .replace(/'/g, '"');
-        setupMemberMap(JSON.parse(data));
-    }
+    let data = JSON.parse($('#slack_member_tz_count').html());
+    setupMemberMap(data);
 });

--- a/pyslackers_website/slack/tests/test_views.py
+++ b/pyslackers_website/slack/tests/test_views.py
@@ -1,3 +1,6 @@
+import json
+import random
+
 import pook
 import pytest
 from django.contrib.messages.middleware import MessageMiddleware
@@ -8,7 +11,7 @@ from django.urls import reverse
 from ratelimit.exceptions import Ratelimited
 
 from pyslackers_website.slack.models import Membership
-from pyslackers_website.slack.views import SlackInvite
+from pyslackers_website.slack.views import SlackInvite, timezone_json_view
 
 
 @pytest.mark.django_db
@@ -25,7 +28,6 @@ class TestSlackInviteView:
         response = SlackInvite.as_view()(request)
         assert response.status_code == 200
         assert response.context_data['slack_member_count'] == 0
-        assert response.context_data['slack_member_tz_count'] == {}
 
     def test_user_count_and_tz_count(self, rf):
         """Assert slack member data is properly being pulled"""
@@ -37,7 +39,6 @@ class TestSlackInviteView:
         response = SlackInvite.as_view()(request)
         assert response.status_code == 200
         assert response.context_data['slack_member_count'] == 7
-        assert response.context_data['slack_member_tz_count'] == slack_member_tz_count
 
     def test_gets_latest_user_and_tz_count(self, rf):
         Membership.objects.create(bot_count=0, deleted_count=0, member_count=7,
@@ -60,7 +61,6 @@ class TestSlackInviteView:
 
             assert response.status_code == 200
             assert response.context_data['slack_member_count'] == new_membership.member_count
-            assert response.context_data['slack_member_tz_count'] == new_membership.tz_count_json
 
     def test_view_rate_limit(self, rf):
         """"""
@@ -90,3 +90,40 @@ class TestSlackInviteView:
         assert response.status_code == 302
         assert pook.isdone()
         assert len(request._messages) == 1  # don't really care about the text
+
+
+@pytest.mark.django_db
+class TestTimezoneJsonView:
+    @property
+    def url(self) -> str:
+        return reverse('slack:timezones')
+
+    def do_request(self, rf):
+        response = timezone_json_view(rf.get(self.url))
+        assert response.status_code == 200
+        return json.loads(response.content)
+
+    def test_empty_object_if_none(self, rf):
+        body = self.do_request(rf)
+        assert body == {}
+
+    def test_json_format(self, rf):
+        Membership.objects.create(bot_count=1, deleted_count=1, member_count=1,
+                                  tz_count_json={
+                                      'TestArea1': 10,
+                                      'TestArea2': 5,
+                                      'TestArea3': 100
+                                  })
+        body = self.do_request(rf)
+        assert body == {
+            'TestArea3': 100,
+            'TestArea1': 10,
+            'TestArea2': 5,
+        }
+
+    def test_only_gives_first_100(self, rf):
+        areas = {f'TestArea{x}': random.choice(range(1, 50)) for x in range(105)}
+        Membership.objects.create(bot_count=1, deleted_count=1, member_count=1,
+                                  tz_count_json=areas)
+        body = self.do_request(rf)
+        assert len(body.keys()) == 100

--- a/pyslackers_website/slack/tests/test_views.py
+++ b/pyslackers_website/slack/tests/test_views.py
@@ -25,15 +25,13 @@ class TestSlackInviteView:
         response = SlackInvite.as_view()(request)
         assert response.status_code == 200
         assert response.context_data['slack_member_count'] == 0
-        assert response.context_data['slack_member_tz_count'] == []
+        assert response.context_data['slack_member_tz_count'] == {}
 
     def test_user_count_and_tz_count(self, rf):
         """Assert slack member data is properly being pulled"""
-        slack_member_tz_count = [('TestArea', 5), ('TestArea2', 2)]
-        Membership.objects.create(bot_count=0,
-                                  deleted_count=0,
-                                  member_count=7,
-                                  tz_count_json=dict(slack_member_tz_count))
+        slack_member_tz_count = {'TestArea': 5, 'TestArea2': 2}
+        Membership.objects.create(bot_count=0, deleted_count=0, member_count=7,
+                                  tz_count_json=slack_member_tz_count)
 
         request = rf.get(self.url)
         response = SlackInvite.as_view()(request)
@@ -60,12 +58,9 @@ class TestSlackInviteView:
             request = rf.get(self.url)
             response = view(request)
 
-            new_tz = [(k, v) for k, v in new_membership.tz_count_json.items()]
-            new_tz.reverse()
-
             assert response.status_code == 200
             assert response.context_data['slack_member_count'] == new_membership.member_count
-            assert response.context_data['slack_member_tz_count'] == new_tz
+            assert response.context_data['slack_member_tz_count'] == new_membership.tz_count_json
 
     def test_view_rate_limit(self, rf):
         """"""

--- a/pyslackers_website/slack/urls.py
+++ b/pyslackers_website/slack/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import SlackInvite
+from .views import SlackInvite, timezone_json_view
 
 
 app_name = 'slack'
 
 urlpatterns = [
     path('', SlackInvite.as_view(), name='index'),
+    path('api/timezones', timezone_json_view, name='timezones'),
 ]

--- a/pyslackers_website/slack/views.py
+++ b/pyslackers_website/slack/views.py
@@ -31,7 +31,7 @@ class SlackInvite(FormView):
 
         context.update(
             slack_member_count=member_count,
-            slack_member_tz_count=Counter(tz_count_json).most_common(100),
+            slack_member_tz_count=dict(Counter(tz_count_json).most_common(100)),
         )
         return context
 

--- a/pyslackers_website/templates/slack/index.html
+++ b/pyslackers_website/templates/slack/index.html
@@ -18,7 +18,9 @@
         </h2>
 
         {% if slack_member_tz_count %}
-            <div id="slack_member_tz_count" style="display: none;" data-timezones="{{ slack_member_tz_count }}"></div>
+            <script id="slack_member_tz_count" type="application/json">
+                {{ slack_member_tz_count | tojson }}
+            </script>
             {% include 'slack/partials/member_map.html' %}
         {% endif %}
 

--- a/pyslackers_website/templates/slack/index.html
+++ b/pyslackers_website/templates/slack/index.html
@@ -17,13 +17,7 @@
             </span>
         </h2>
 
-        {% if slack_member_tz_count %}
-            <script id="slack_member_tz_count" type="application/json">
-                {{ slack_member_tz_count | tojson }}
-            </script>
-            {% include 'slack/partials/member_map.html' %}
-        {% endif %}
-
+        {% include 'slack/partials/member_map.html' %}
         {% include 'slack/partials/invite_form.html' %}
     </div>
 {% endblock %}

--- a/pyslackers_website/templates/slack/partials/member_map.html
+++ b/pyslackers_website/templates/slack/partials/member_map.html
@@ -1,3 +1,3 @@
-<div class="ui container segment" id="leaflet_container">
+<div class="ui loading container segment" id="leaflet_container">
     <div id="leaflet_member_map" style="min-height: 425px;"></div>
 </div>


### PR DESCRIPTION
### Relevant Issue & Description

Converts the timezone count pass-off async and requires some jquery fetching from the server (rather than an awkward template -> js handoff with the compiled bundles).

### Screenshots, if applicable

n/a

### Requirements

- [x] Tests (required)
- [ ] Documentation (if applicable)
- [ ] Ansible updates (if applicable)
