### PR TITLE
#176: Fix swallowed error of duplicate emails for invite tracking

### DIFF
--- a/app/slack/tasks.py
+++ b/app/slack/tasks.py
@@ -29,7 +29,7 @@ def send_slack_invite(email: str, *, channels: Optional[List[str]] = None,
     slack = SlackClient(settings.SLACK_OAUTH_TOKEN)
     try:
         if slack.invite(email, channels, resend=resend):
-            Invite.objects.create(email=email)
+            Invite.objects.get_or_create(email=email)
         logger.info('Successfully sent invite to %s', email)
     except SlackException as e:
         logger.error('Error sending invite to %s because %s', email, e)

--- a/app/slack/views.py
+++ b/app/slack/views.py
@@ -49,7 +49,7 @@ class SlackInvite(FormView):
 
 
 def timezone_json_view(request):
-    """View to get the user timezones """
+    """View to get the user timezones"""
     try:
         tzs = Membership.objects.latest().tz_count_json
     except Membership.DoesNotExist:

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import sys
 
+
 if __name__ == '__main__':
     if sys.version_info < (3, 6):
         raise SystemExit('This project uses features only in Python 3.6+, '


### PR DESCRIPTION
### Relevant Issue & Description

Closes #176: Duplicate invites may be sent if someone never accepted and comes back later.

### Screenshots, if applicable

n/a

### Requirements

- [ ] Tests (required)
- [ ] Documentation (if applicable)
- [ ] Ansible updates (if applicable)
