### PR TITLE
Fix for celery beat on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ app/static/dist/
 # editors
 .idea/
 .vscode
+
+celerybeat\.pid

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
-app: ./manage.py runserver
-worker: celery -A config worker --beat -l info
+app: python manage.py runserver
+worker: celery -A config worker -l info
+scheduler: celery -A config beat
 assets: yarn run start


### PR DESCRIPTION
Split celery beat into a separate service
Changed to python manage.py instead of ./manage.py

I am not entirely sure how to properly test this, I don't get any errors or warnings and the site seems to load properly. However, I am not really sure what the -- beat/scheduler was doing to confirm it is working.
