### PR TITLE
Redis URL wasn't being used in one spot when running test suite

### DIFF
--- a/config/settings/testing.py
+++ b/config/settings/testing.py
@@ -3,7 +3,7 @@ import os
 from ._base import *  # noqa
 
 
-CACHES['default']['LOCATION'] = 'redis://localhost:6379/1'  # noqa
+CACHES['default']['LOCATION'] = os.getenv('REDIS_URL', 'redis://localhost:6379/1')  # noqa
 
 BROKER_URL = os.getenv('REDIS_URL', 'redis://localhost:6379/1')
 


### PR DESCRIPTION
If you were overriding the Redis URL you would get a few broken tests, this will fix it.