### PR TITLE
Email validators need to check to make sure there is an @

### DIFF
--- a/app/marketing/validators.py
+++ b/app/marketing/validators.py
@@ -8,6 +8,8 @@ def validate_not_burner_domain(email: str):
     """Validate that the provided email is not considered a "burner"
     domain, e.g. someone not interested in committing and contributing to
     the community or the ability to recover their account."""
+    if '@' not in email:
+        return
     email, domain = email.split('@')
     try:
         BurnerDomain.objects.get(domain__iexact=domain)

--- a/app/marketing/validators.py
+++ b/app/marketing/validators.py
@@ -9,7 +9,7 @@ def validate_not_burner_domain(email: str):
     domain, e.g. someone not interested in committing and contributing to
     the community or the ability to recover their account."""
     if '@' not in email:
-        return
+        raise ValidationError(_('Enter a valid email address'))
     email, domain = email.split('@')
     try:
         BurnerDomain.objects.get(domain__iexact=domain)

--- a/app/slack/tests/test_slack_forms.py
+++ b/app/slack/tests/test_slack_forms.py
@@ -19,3 +19,11 @@ class TestSlackInviteForm:
             'accept_tos': True,
         })
         assert form.is_valid()
+
+    def test_invalid_email(self):
+        form = SlackInviteForm({
+            'email': 'foo#bar.com',
+            'accept_tos': True,
+        })
+        assert not form.is_valid()
+        assert set(form.errors.keys()) == {'email'}

--- a/app/slack/validators.py
+++ b/app/slack/validators.py
@@ -12,7 +12,7 @@ def validate_not_duplicate_email(email: str):
     invite from us. In the rare case someone needs a second
     we can manually do it for now via our email."""
     if '@' not in email:
-        return
+        raise ValidationError(_('Enter a valid email address'))
     username, domain = email.split('@')
     stripped_username = re.sub(r'(?:\.|\+.*$)', '', username)
     matching_invites = Invite.objects.filter(

--- a/app/slack/validators.py
+++ b/app/slack/validators.py
@@ -11,6 +11,8 @@ def validate_not_duplicate_email(email: str):
     """Validate that the email has not already received an
     invite from us. In the rare case someone needs a second
     we can manually do it for now via our email."""
+    if '@' not in email:
+        return
     username, domain = email.split('@')
     stripped_username = re.sub(r'(?:\.|\+.*$)', '', username)
     matching_invites = Invite.objects.filter(


### PR DESCRIPTION
Django email form will raise a validation error already if its not a valid email, so we can just pass on our additional checks.

### Relevant Issue & Description

Fixes #199 
Basically, you can't assume the email passed into the validator is valid.

### Requirements

- [ ] Tests (required)
