### PR TITLE
Fixed regression of triple error messages when entering an invalid email address.

### DIFF
--- a/app/marketing/validators.py
+++ b/app/marketing/validators.py
@@ -9,7 +9,7 @@ def validate_not_burner_domain(email: str):
     domain, e.g. someone not interested in committing and contributing to
     the community or the ability to recover their account."""
     if '@' not in email:
-        raise ValidationError(_('Enter a valid email address'))
+        return
     email, domain = email.split('@')
     try:
         BurnerDomain.objects.get(domain__iexact=domain)

--- a/app/slack/tests/test_slack_forms.py
+++ b/app/slack/tests/test_slack_forms.py
@@ -26,4 +26,5 @@ class TestSlackInviteForm:
             'accept_tos': True,
         })
         assert not form.is_valid()
+        assert len(form.errors['email']) == 1
         assert set(form.errors.keys()) == {'email'}

--- a/app/slack/validators.py
+++ b/app/slack/validators.py
@@ -12,7 +12,7 @@ def validate_not_duplicate_email(email: str):
     invite from us. In the rare case someone needs a second
     we can manually do it for now via our email."""
     if '@' not in email:
-        raise ValidationError(_('Enter a valid email address'))
+        return
     username, domain = email.split('@')
     stripped_username = re.sub(r'(?:\.|\+.*$)', '', username)
     matching_invites = Invite.objects.filter(


### PR DESCRIPTION
Validators that have not met there prerequisites return early.
If a validator is unable to check that the data is valid, it is not invalid it is unknown and we do nothing instead.
Also added a check to make sure there is only 1 email error instead of 3.

### Relevant Issue & Description

Fixes #207 

### Requirements

- [ ] Tests (required)
- [ ] Documentation (if applicable)
- [ ] Ansible updates (if applicable)
