### PR TITLE
Upgrade celery to 4.1.1 to fix kombu incompatibility

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-celery==4.1.0
+celery==4.1.1
 dj-database-url==0.5.0
 Django==2.0.5
 django-celery-beat==1.1.1


### PR DESCRIPTION
### Relevant Issue & Description

_Reference the issue, include keywords like "Fixes" (see [GitHub](https://help.github.com/articles/closing-issues-via-commit-messages/) docs)_

### Screenshots, if applicable

_Show screenshots of what is new/different_

### Requirements

- [ ] Tests (required)
- [ ] Documentation (if applicable)
- [ ] Ansible updates (if applicable)
