### PR TITLE
Following the psycopg2 docs, opt out of using the binary release

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ django-debug-toolbar==1.9.1
 django-ratelimit==1.1.0
 django-redis==4.9.0
 Markdown==2.6.10
-psycopg2==2.7.5
+psycopg2==2.7.5 --no-binary psycopg2
 Pygments==2.2.0
 raven==6.9.0
 redis==2.10.6


### PR DESCRIPTION
Systems that already have psycopg==2.7.5 already installed may need to
remove and re-install it.

Closes #256 - instead of using `-binary` we follow their recommendation of building it.
