### PR TITLE
Add the PSF CoC to our own CoC.

### DIFF
--- a/app/templates/marketing/terms_of_service.html
+++ b/app/templates/marketing/terms_of_service.html
@@ -53,7 +53,7 @@
             project and
             our community a harassment-free experience for everyone, regardless
             of age, body
-            size, disability, ethnicity, gender identity and expression, level
+            types, disability, ethnicity, gender identity and expression, level
             of experience,
             nationality, personal appearance, race, religion, or sexual identity
             and

--- a/app/templates/marketing/terms_of_service.html
+++ b/app/templates/marketing/terms_of_service.html
@@ -41,10 +41,15 @@
 
         <h1 class="ui dividing header" id="code_of_conduct">Code of Conduct</h1>
 
+        <p>As a Python community we are beholden to the Python Software Foundation (PSF)
+           <a href="https://www.python.org/psf/codeofconduct/">Code of Conduct</a>.
+        </p>
+        <p>This is extended by our own PySlackers Code of Conduct detailed below:</p>
+
         <h2 class="ui header" id="our_pledge">Our Pledge</h2>
 
         <p>In the interest of fostering an open and welcoming environment, we as
-            contributors and maintainers pledge to making participation in our
+            contributors and maintainers pledge to make participation in our
             project and
             our community a harassment-free experience for everyone, regardless
             of age, body
@@ -55,6 +60,25 @@
             orientation.</p>
 
         <h2 class="ui header" id="our_standards">Our Standards</h2>
+
+        <p>As a community we are:</p>
+        <ul>
+            <li>
+                <a href="https://www.python.org/psf/codeofconduct/#open">Open</a> to collaboration, change and
+                constructive comment and criticism from any and all members of the community
+            </li>
+            <li>
+                <a href="https://www.python.org/psf/codeofconduct/#considerate">Considerate</a> of our members in all
+                communication. We appreciate that everyone wants to contribute to make our community a better place
+                and, as a result, give appropriate thought and care in our responses
+            </li>
+            <li>
+                <a href="https://www.python.org/psf/codeofconduct/#respectful">Respectful</a> of our members, their
+                wide variety of cultures, experiences and skills. We respect that everyone contributing is a volunteer
+                and we treat each other with courtesy when disagreements do arise
+            </li>
+
+        </ul>
 
         <p>Examples of behavior that contributes to creating a positive
             environment
@@ -95,6 +119,8 @@
         </ul>
 
         <h2 class="ui header" id="our_responsibilities">Our Responsibilities</h2>
+
+        </p>
 
         <p>Project maintainers are responsible for clarifying the standards of
             acceptable
@@ -149,10 +175,12 @@
 
         <h2 class="ui header" id="attribution">Attribution</h2>
 
-        <p>This Code of Conduct is adapted from the <a
-                href="http://contributor-covenant.org">Contributor Covenant</a>,
-            version 1.4,
-            available at <a href="http://contributor-covenant.org/version/1/4/">http://contributor-covenant.org/version/1/4</a>.
+        <p>This Code of Conduct is adapted from both the
+            <a href="http://contributor-covenant.org">Contributor Covenant</a>,
+            version 1.4 available at
+            <a href="http://contributor-covenant.org/version/1/4/">http://contributor-covenant.org/version/1/4</a>,
+            and the <a href="https://www.python.org/psf/">PSF</a> Code of Conduct available at
+            <a href="https://www.python.org/psf/codeofconduct/">https://www.python.org/psf/codeofconduct/</a>.
         </p>
 
         <h1 class="ui dividing header" id="tldr">TL;DR</h1>
@@ -160,10 +188,10 @@
         <ul>
             <li>You are bound by the terms of Slack, if you join the Slack team</li>
             <li>The community projects collect a small amount of Slack data through a bot and this website - but it is not sold, shared, or otherwise available outside the admins</li>
-            <li>You agree to abide by our <a href="#code_of_conduct">Code of Conduct</a></li>
+            <li>You agree to abide by our <a href="#code_of_conduct">Code of Conduct</a> as well as the <a href="https://www.python.org/psf/codeofconduct/#respectful">PSF Code of Conduct</a></li>
             <li>All projects are run in the open: audit them at <a href="https://github.com/pyslackers" target="_blank">github.com/pyslackers</a></li>
             <li>Destructive users will have their accounts deactivated if they do not respond to admin warnings.</li>
-            <li>Cookies are used on this site, for authentication and data protection (CSRF).</li>
+            <li>Cookies are used on this site, for authentication and data protection (CSRF)</li>
             <li>Use the <a href="https://github.com/pyslackers/community/issues/new?labels=topic/code%20of%20conduct"><i class="icon github"></i>Community Issue Tracker</a> for community related issues</li>
         </ul>
     </div>


### PR DESCRIPTION
As a Python community we should adhere to python standards.
With this in mind we are extending our CoC to encompass the official
PSF CoC found here: https://www.python.org/psf/codeofconduct/

We have made clear that this is the case and have added some
paraphrased parts of the PSF CoC to our pledge to emphasise the point.

### Screenshots, if applicable


<img width="1142" alt="screen shot 2018-07-21 at 21 51 15" src="https://user-images.githubusercontent.com/6662648/43039990-d89f6462-8d30-11e8-92d6-c5979ffd6c3e.png">
<img width="1225" alt="screen shot 2018-07-21 at 21 50 41" src="https://user-images.githubusercontent.com/6662648/43039991-db8c00c2-8d30-11e8-8581-be0ba8151b82.png">
