### PR TITLE
construct copyright year in footer on the fly

### DIFF
--- a/app/templates/marketing/partials/footer.html
+++ b/app/templates/marketing/partials/footer.html
@@ -3,7 +3,7 @@
     <div class="ui center aligned container">
         <div class="ui stackable inverted divided grid">
             <div class="nine wide column text-muted middle aligned">
-                &copy; 2017 PySlackers
+                &copy; {% now "Y" %} PySlackers
             </div>
 {#            <div class="three wide column"></div>#}
 {#            <div class="three wide column"></div>#}


### PR DESCRIPTION
### Relevant Issue & Description
The copyright year in the footer was outdated, so I made it always dated.