### PR TITLE
Remove "production" target in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-alpine AS production
+FROM python:3.7.3-alpine
 WORKDIR /app
 
 ENV PORT=8000 \
@@ -12,12 +12,8 @@ RUN apk add --no-cache tzdata gcc g++ make && \
     echo "UTC" >> /etc/timezone && \
     apk del tzdata
 
-RUN pip install -r requirements/production.txt
+RUN pip install -r requirements/development.txt
 
 COPY . .
 
 CMD gunicorn pyslackersweb:app_factory --bind=0.0.0.0:${PORT} --worker-class=aiohttp.GunicornWebWorker
-
-FROM production AS development
-
-RUN pip install -r requirements/development.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,8 @@ version: "3.4"
 
 services:
   web:
-    image: pyslackers/website
-    build:
-      context: .
-      target: development
+    image: pyslackers/website:dev
+    build: .
     environment:
       SLACK_OAUTH_TOKEN: "${SLACK_OAUTH_TOKEN}"
     ports:


### PR DESCRIPTION
We deploy to platform.sh, so we don't need a prod image. Instead let's optimize the dev image for turnaround time/dev experience.