### PR TITLE
Use branch name as the environment for sentry

### DIFF
--- a/pyslackersweb/__init__.py
+++ b/pyslackersweb/__init__.py
@@ -29,7 +29,7 @@ sentry_sdk.init(
         LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
     ],
     release=os.getenv("PLATFORM_TREE_ID"),
-    environment=os.getenv("PLATFORM_ENVIRONMENT"),
+    environment=os.getenv("PLATFORM_BRANCH"),
 )
 
 


### PR DESCRIPTION
This ensures that all related errors are in the same env, the variable
we were using included a hash at the end and would cause issues to not
be related across deploys of the same branch
