### PR TITLE
Fix slack rate limiting issue, refactor tasks

### DIFF
--- a/pyslackersweb/__init__.py
+++ b/pyslackersweb/__init__.py
@@ -11,7 +11,7 @@ from jinja2.filters import FILTERS
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
 
-from .contexts import background_jobs, client_session, slack_client
+from .contexts import background_jobs, client_session, apscheduler, slack_client
 from .filters import formatted_number
 from .middleware import request_context_middleware
 from .views import routes  # , on_oauth2_login
@@ -59,9 +59,9 @@ async def app_factory() -> web.Application:
         filters={"formatted_number": formatted_number, **FILTERS},
     )
 
-    app.cleanup_ctx.append(client_session)
-    app.cleanup_ctx.append(slack_client)
-    app.cleanup_ctx.append(background_jobs)
+    # this ordering is important, before reordering be sure to check
+    # for dependencies.
+    app.cleanup_ctx.extend([apscheduler, client_session, slack_client, background_jobs])
 
     app.add_routes(routes)
     app.router.add_static(app["static_root_url"], package_root / "static")

--- a/pyslackersweb/tasks.py
+++ b/pyslackersweb/tasks.py
@@ -83,7 +83,7 @@ def sync_slack_users(app: web.Application):
 
         try:
             counter = Counter()
-            async for user in client.iter(slack.methods.USERS_LIST):
+            async for user in client.iter(slack.methods.USERS_LIST, minimum_time=3):
                 if user["deleted"] or user["is_bot"] or not user["tz"]:
                     continue
 


### PR DESCRIPTION
* Breaks the scheduler out into it's own cleanup_ctx
* Leverages next_run_time in APScheduler to trigger the initial syncs
instead of explicitly calling the methods
* Adds 3sec minimum_time to the user sync in slack (Tier2 allows 20req
per minute)