### PR TITLE
No access log on platform.sh & warnings to sentry

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -17,7 +17,7 @@ web:
   upstream:
     socket_family: unix
   commands:
-    start: "gunicorn --workers 1 --bind unix:$SOCKET --access-logfile - --worker-class aiohttp.worker.GunicornWebWorker pyslackersweb:app_factory"
+    start: "gunicorn --workers 1 --bind unix:$SOCKET --worker-class aiohttp.worker.GunicornWebWorker pyslackersweb:app_factory"
   locations:
     "/":
       passthru: true

--- a/pyslackersweb/__init__.py
+++ b/pyslackersweb/__init__.py
@@ -15,6 +15,7 @@ from . import settings, website
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
+logging.captureWarnings(True)
 logging.getLogger(__name__).setLevel(logging.DEBUG)
 
 
@@ -22,7 +23,7 @@ sentry_sdk.init(
     dsn=settings.SENTRY_DSN,
     integrations=[
         AioHttpIntegration(),
-        LoggingIntegration(level=logging.INFO, event_level=logging.ERROR),
+        LoggingIntegration(level=logging.DEBUG, event_level=logging.WARNING),
     ],
     release=settings.SENTRY_RELEASE,
     environment=settings.SENTRY_ENVIRONMENT,


### PR DESCRIPTION
- We do not need explicit access log on platform.sh.
  They are already send to /var/log/access.log

- Warnings usually needs to be acted on. Send them to sentry
  so we do not need to check the logs

- Send python warnings to logging
