### PR TITLE
Enable more caching

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -1,8 +1,10 @@
 "https://{default}/":
   type: upstream
   upstream: "website:http"
+  cache:
+    enabled: true
+    default_ttl: 3600
   redirects:
-    expires: 1d
     paths:
       '/':
         to: "/web"


### PR DESCRIPTION
Add required options to cache GET response from the app. Currently all GET request can be cached, in the future we might want to control the cache behavior by setting appropriate headers.