### PR TITLE
Bump sentry version, enable Sqlalchemy integration

### DIFF
--- a/pyslackersweb/__init__.py
+++ b/pyslackersweb/__init__.py
@@ -10,6 +10,7 @@ from aiohttp import ClientSession, web
 from aiohttp_remotes import XForwardedRelaxed, ForwardedRelaxed
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
 from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 
 from .contexts import apscheduler, client_session, redis_pool, postgresql_pool
 from .middleware import request_context_middleware
@@ -28,6 +29,7 @@ sentry_sdk.init(
     integrations=[
         AioHttpIntegration(),
         LoggingIntegration(level=logging.DEBUG, event_level=logging.WARNING),
+        SqlalchemyIntegration(),
     ],
     release=settings.SENTRY_RELEASE,
     environment=settings.SENTRY_ENVIRONMENT,

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ apscheduler==3.6.1
 asyncpgsa==0.26.0
 gunicorn==19.9.0
 marshmallow==3.2.1
-sentry-sdk==0.13.0
+sentry-sdk==0.14.1
 slack-sansio==1.1.0
 psycopg2-binary==2.8.4
 pyyaml==5.1.2


### PR DESCRIPTION
Sentry recommended the sqlalchemy integration, I am not sure if or how well it works with async but figured we could try it out.