### PR TITLE
Cleanup channel table on non-production environment

### DIFF
--- a/pyslackersweb/settings.py
+++ b/pyslackersweb/settings.py
@@ -11,6 +11,8 @@ SENTRY_ENVIRONMENT = os.getenv("PLATFORM_BRANCH")
 
 SENTRY_RELEASE = os.getenv("PLATFORM_TREE_ID")
 
+IS_PRODUCTION = os.getenv("PLATFORM_BRANCH") == "master"
+
 # This must be an admin user's token on the team
 SLACK_INVITE_TOKEN = os.getenv("SLACK_INVITE_TOKEN", os.getenv("SLACK_OAUTH_TOKEN"))
 


### PR DESCRIPTION
channel sync create db conflict on non-production environment as they are populated with the master data. channel name are supposed to be unique but that's not the case across two teams

See: https://sentry.io/organizations/pyslackers/issues/1810007072