### PR TITLE
Fix local development environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apk add --no-cache tzdata gcc g++ make postgresql-dev build-base git && \
     apk del tzdata
 
 COPY requirements requirements
-RUN pip install -r requirements/development.txt
+RUN pip install -U pip && \
+    pip install -r requirements/development.txt
 
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   web:
     image: pyslackers/website:dev
@@ -27,12 +25,17 @@ services:
   postgresql:
     image: postgres:11
     ports:
-      - 5432:5432
+      - 5435:5432
     environment:
       POSTGRES_USER: "${USER}"
       POSTGRES_PASSWORD: ""
       POSTGRES_DB: "pyslackers_dev"
       POSTGRES_HOST_AUTH_METHOD: "trust"
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${USER}", "-d", "pyslackers_dev"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   tox-data: {}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,7 +11,7 @@ marshmallow==3.11.1
 sentry-sdk==1.0.0
 slack-sansio==1.1.0
 psycopg2-binary==2.8.6
-pyyaml==5.4.1
+pyyaml==6.0.2
 uvloop==0.15.2
 sqlalchemy==1.3.23
 urllib3<2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 aiohttp-jinja2==1.5
 aiohttp-oauth2==0.0.3
 aiohttp-remotes==1.0.0
-aiohttp==3.7.4.post0
+aiohttp==3.10.11
 aioredis==1.3.1
 alembic==1.5.8
 apscheduler==3.7.0


### PR DESCRIPTION
### Description

This set of changes is intentionally targeted to allow me to develop the website locally. Because the website has not been maintained for many years, the initial steps outlined in the CONTRIBUTING.md file were not working as expected. I aimed to make the initial changes so that `docker-compose up --build` would allow to view the site at localhost:8000.

The main changes are upgrades of pyyaml and aiohttp. The building of the pyyaml wheel was failing so I updated the Dockerfile to upgrade pip. After that, aiohttp caused an error when the port number was included in the URL to run locally, which is difficult to work around. I did some research, and according to SO, the fix was to upgrade aiohttp. I upgraded it to the highest version before they stopped Python 3.8 support. In future work, I plan on upgrading the Python version.


### Screenshots, if applicable

Successful loading of the website from localhost:8000

<img width="533" alt="image" src="https://github.com/user-attachments/assets/658f5df6-bd4b-4220-82ff-1893d08f46d7" />
