### PR TITLE
Make the local dev workflow better

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,36 @@
-# The Easy Path (recommended)
+# How to contribute
 
-To get started on the easy path, you simply need [`docker`](https://www.docker.com/get-started) and [`docker-compose`](https://docs.docker.com/compose/). By utilizing docker and compose you don't need to think about anything on your host system (python versions, virtual environments, etc). Instead you can run the following and be ready to rock:
+## Development internals
+
+* [Docker](https://www.docker.com/get-started)
+* [docker-compose](https://docs.docker.com/compose)
+* Python 3.8
+* tox
+
+##  Quickstart
+
+To get the application running quickly the entire stack can be started by running the following:
 
 ```bash
 $ docker-compose up --build
 ```
 
-This will build the docker container for you which uses the correct [python version](.python-version), installs the dependencies, and binds the ports. This also "volume mounts" your local directory into the container, meaning that any changes you make on your host machine will be available in the docker container. The exception to these changes being reflected immediately will be if/when a dependency is added or updated, in which case you'll need to run the above command again (basically just ctrl-c, up arrow, enter, and wait for the rebuild).
+By utilizing docker and compose you don't need to think about anything on your host system (python versions, virtual environments, etc). This will build the docker container for you which uses the correct [python version](.python-version), installs the dependencies, and binds the ports. This also "volume mounts" your local directory into the container, meaning that any changes you make on your host machine will be available in the docker container. The exception to these changes being reflected immediately will be if/when a dependency is added or updated, in which case you'll need to run the above command again (basically just ctrl-c, up arrow, enter, and wait for the rebuild).
 
-## Testing
+### Testing with all services running w/ docker compose
 
 While you can allow for CircleCI to run tests/checks, running locally simply uses `docker` and `tox`:
 
 ```bash
 # if you need to rebuild first, `docker-compose build`
 
-$ docker-compose run --rm web tox
+$ docker-compose run --rm web tox -e test
 ```
 
 Tox forwards positional arguments to pytest, that way you can use all standard pytest arguments. For example, only running a specific test can be done like this:
 
 ```bash
-$ docker-compose run --rm web tox -e py37 tests/test_website.py::test_endpoint_index
+$ docker-compose run --rm web tox -e test tests/test_website.py::test_endpoint_index
 ```
 
 To run the black auto-formatter on the code you can use:
@@ -30,7 +39,7 @@ To run the black auto-formatter on the code you can use:
 $ docker-compose run --rm web tox -e autoformat
 ```
 
-# The Involved Path
+## Running the application locally
 
 If instead you'd prefer to set-up your project on the host machine, you are free to do so. This is a non-exhaustive primer on the steps required, if you need help directly please ask in [#community_projects](slack://open?team=T07EFKXHR&id=C2FMLUBEU).
 
@@ -38,7 +47,7 @@ If instead you'd prefer to set-up your project on the host machine, you are free
 
 ### 1. Python Version
 
-If you have [`pyenv`](https://github.com/pyenv/pyenv) installed already, the [python version](.python-version) should be set automatically for you based on the `.python-version` file. However if you do not, you should make sure that Python3.7+ is available on your host.
+If you have [`pyenv`](https://github.com/pyenv/pyenv) installed already, the [python version](.python-version) should be set automatically for you based on the `.python-version` file. However if you do not, you should make sure that Python 3.8 is available on your host.
 
 ### 2. Virtual Environment
 
@@ -46,11 +55,12 @@ For a host of reasons that are covered elsewhere, you should never install depen
 
 ```bash
 $ python -V
-Python 3.7.3
+Python 3.8.16
 $ python -m venv .venv
 ```
 
 You will now have a directory in your project called `.venv`, which is ignored by source control as it is not portable. You need to activate this _per shell instance_.
+
 
 ```bash
 $ source .venv/bin/activate
@@ -79,26 +89,41 @@ Now you need the dependencies installed, which is as simple as:
 (.venv) $ pip install -r requirements/development.txt
 ```
 
+OR run the above steps with the following make command:
+
+```bash
+$ make install
+```
+
 ### 4. Environment (optional)
 
 If you want to test changes and make sure things work, you can copy the [`.env.sample`](.env.sample) to `.env` and add in the required configuration variables to work. You may want to set up a "dev" slack team for this.
 
-### 5. Runtime Dependencies
+### 5. Run the services
 
 You'll need to run the following:
 
-* `redis`
-    * You can do this easily with `docker run --rm -it -p 6379:6379 redis:5-alpine`
+```bash
+make setup_services
+```
 
 ### 6. Run the App
 
 Now you should be good to run the application:
 
 ```bash
-(.venv) $ gunicorn --bind 127.0.0.1:8000 --worker-class aiohttp.GunicornWebWorker --reload pyslackersweb:app_factory
+make start_app
 ```
-
 Once that launches you can visit [localhost:8000](http://localhost:8000) in your browser and be in business.
+
+### 7. Run tests locally
+
+To run the tests with automatic setup and teardown of services simply run:
+
+```bash
+# Ensure the virtualenv is activated i.e source .venv/bin/activate
+tox
+```
 
 ## Windows Systems
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+.PHONY: clean install formatter lint types static-checks test up down setup_services start_app
+help:
+	@echo "make"
+	@echo "    clean"
+	@echo "        Remove Python/build artifacts."
+	@echo "    install"
+	@echo "        Create a virtual environment and install dependencies."
+	@echo "    formatter"
+	@echo "        Apply black formatting to code."
+	@echo "    lint"
+	@echo "        Lint code with pylint, and check if black formatter should be applied."
+	@echo "    types"
+	@echo "        Check for type errors using mypy."
+	@echo "    static-checks"
+	@echo "        Run all python static checks."
+	@echo "    test"
+	@echo "        Run pytest on tests/."
+	@echo "    up"
+	@echo "        Start the services and the gunicorn server"
+	@echo "    down"
+	@echo "        Stop the services"
+	@echo "    setup_services"
+	@echo "        Setup required services using tox."
+	@echo "    start_server"
+	@echo "        Start the gunicorn server."
+
+clean:
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f  {} +
+	rm -rf .mypy_cache/
+	rm -rf .venv/
+
+install:
+	python3 -m venv .venv
+	source .venv/bin/activate
+	pip3 install -U pip
+	pip3 install -r ./requirements/development.txt
+
+formatter:
+	tox -e autoformat
+
+format: formatter
+
+lint:
+	tox -e lint
+
+types:
+	tox -e mypy
+
+static-checks: lint types
+
+test:
+	tox -e test
+
+up: setup_services start_server
+
+setup_services:
+	tox -e setup_services
+
+start_app:
+	.venv/bin/gunicorn --bind 127.0.0.1:8000 --worker-class aiohttp.GunicornWebWorker --reload pyslackersweb:app_factory
+
+down:
+	tox -e teardown_services

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,13 @@ services:
     image: pyslackers/website:dev
     build: .
     depends_on:
-      - redis
-      - postgresql
+      redis:
+        condition: service_started
+      postgresql:
+        condition: service_healthy
     environment:
       REDIS_URL: "redis://redis:6379/0"
-      DATABASE_URL: "postgresql://${USER}:@postgresql:5432/pyslackers_dev"
+      DATABASE_URL: "postgresql://pyslackersweb:pyslackersweb@postgresql:5432/pyslackersweb_dev"
       SLACK_INVITE_TOKEN: "${SLACK_INVITE_TOKEN}"
       SLACK_TOKEN: "${SLACK_TOKEN}"
     ports:
@@ -26,14 +28,11 @@ services:
     image: postgres:11
     ports:
       - 5435:5432
-    environment:
-      POSTGRES_USER: "${USER}"
-      POSTGRES_PASSWORD: ""
-      POSTGRES_DB: "pyslackers_dev"
-      POSTGRES_HOST_AUTH_METHOD: "trust"
+    env_file:
+      - env-postgresql.env
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "${USER}", "-d", "pyslackers_dev"]
-      interval: 10s
+      test: ["CMD", "pg_isready", "-U", "pyslackersweb", "-d", "pyslackersweb_dev"]
+      interval: 5s
       timeout: 5s
       retries: 5
 

--- a/env-postgresql.env
+++ b/env-postgresql.env
@@ -1,0 +1,5 @@
+POSTGRES_USER=pyslackersweb
+POSTGRES_PASSWORD=pyslackersweb
+POSTGRES_DB=pyslackersweb_dev
+POSTGRES_PORT=5432
+POSTGRES_HOST=postgresql

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "pyslackersweb"
+version = "0.0.1"
+description = "The website for the pythondev.slack.com community"
+
+[tool.setuptools]
+packages = ["pyslackersweb"]
+
 [tool.black]
 line-length = 100
 target-version = ["py38"]

--- a/pyslackersweb/settings.py
+++ b/pyslackersweb/settings.py
@@ -1,7 +1,9 @@
 import os
 
 
-DATABASE_URL = os.getenv("DATABASE_URL", "postgres://127.0.0.1:5432/postgres")
+DATABASE_URL = os.getenv(
+    "DATABASE_URL", "postgres://pyslackersweb:pyslackersweb@localhost:5435/pyslackersweb_dev"
+)
 
 REDIS_URL = os.getenv("REDIS_URL", "redis://127.0.0.1:6379/0")
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,6 +12,6 @@ sentry-sdk==1.0.0
 slack-sansio==1.1.0
 psycopg2-binary==2.8.6
 pyyaml==6.0.2
-uvloop==0.15.2
+uvloop==0.21.0
 sqlalchemy==1.3.23
 urllib3<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,57 @@
 [tox]
-envlist = py38,lint
+envlist =
+    lint
+    setup_services
+    test
+    teardown_services
+    mypy
 skipsdist = true
 
 [testenv]
+base_python = python3.8
+allowlist_externals =
+    docker
+deps =
+    -r requirements/testing.txt
+
+[testenv:test]
 passenv =
-    REDIS_URL
     DATABASE_URL
+    REDIS_URL
 commands =
-    pip install -r requirements/testing.txt
     alembic upgrade head
     python -m pytest --verbose --cov=pyslackersweb/ --cov-report=term-missing --junit-xml={envdir}/artifacts/test-results.xml {posargs:tests/}
+depends =
+    setup_services
 
 [testenv:lint]
+ignore_outcome = true
 commands =
-    pip install -r requirements/testing.txt
     black --check .
     pylint pyslackersweb tests migrations
+
+[testenv:mypy]
+deps =
+    ; TODO: remove this pinning once we move to uv and dependency groups
+    mypy==0.812
+commands =
     mypy . --ignore-missing-imports
 
 [testenv:autoformat]
+deps =
+    ; TODO: remove this pinning once we move to uv and dependency groups
+    black==22.3.0
 commands =
-    pip install -r requirements/testing.txt
     black .
+
+[testenv:setup_services]
+skip_install = true
+commands =
+    docker compose up --build -d postgresql redis
+
+[testenv:teardown_services]
+skip_install = true
+commands =
+    docker compose down -v --remove-orphans
+depends =
+    test


### PR DESCRIPTION
## Description

1. The tox setup is heavily directed towards running in the container. While that works well for containers, it starts to break down when running the tox automation locally. This is because tox picks up the Python versions you have installed locally, and unless it is told otherwise, it will use those. I've set tox to use base_python version Python 3.8. We shouldn't assume everyone will want to develop in a container (I don't).
2. Running the Postgres container and the app had some race condition issues. In a previous PR, I added a health check, but this wasn't enough. The app container is now set to wait until the Postgres container is healthy. Additionally, the Postgres config is now done via an env file.
3. Behold! A Makefile!
4. With the Makefile available, I updated the CONTRIBUTING.md file to synchronize things. There is still A LOT in the CONTRIBUTING.md file we could offload to some other docs, but I mainly focused on updating the commands for now.