### PR TITLE
Fix Sentry workflow configuration

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -82,7 +82,7 @@ jobs:
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: pyslackers
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          SENTRY_PROJECT: website
         with:
           environment: production
           release: ${{ github.sha }}


### PR DESCRIPTION
Fixes the SENTRY_ORG missing organization slug error by removing duplicate environment variables and setting them directly.