### PR TITLE
Upgrade Platform.sh runtime to Python 3.12

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: "website"
 
 # The runtime the application uses.
-type: "python:3.8"
+type: "python:3.12"
 
 # The size of the persistent disk of the application (in MB).
 disk: 512  # MB


### PR DESCRIPTION
Updates Platform.sh configuration to use Python 3.12 runtime instead of Python 3.8.

This change aligns the production environment with our codebase that now supports Python 3.12. The application dependencies and code have been tested and are compatible with Python 3.12.

**Changes:**
- Update runtime from `python:3.8` to `python:3.12`

**Testing:**
- Python 3.12 compatibility has been verified in CI/CD
- All tests pass on Python 3.12
- Dependencies are compatible with Python 3.12